### PR TITLE
IAG task fails when SELinux is disabled

### DIFF
--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -239,6 +239,7 @@
     proto: tcp
     setype: http_port_t
     state: present
+  when: ansible_selinux.status == "enabled"
 
 - name: Start Automation Gateway service
   ansible.builtin.service:


### PR DESCRIPTION
Added a test in the main.yml to validate if selinux is enabled or disable to skip the task.