### PR TITLE
Missing SSO parameter in authenticationProps

### DIFF
--- a/roles/platform/templates/profile.j2
+++ b/roles/platform/templates/profile.j2
@@ -121,6 +121,12 @@
     "cookieName": "token",
     "description": "Authentication",
     "logoutTime": 60,
+     {% if iap_release == 2023.2 %}
+    "sso": {
+      "enabled": false,
+      "config": ""
+      },
+    {% endif %}
     "uniqueSession": false
   },
   "description": "{{ vars.desc }}",

--- a/roles/platform/templates/profile.j2
+++ b/roles/platform/templates/profile.j2
@@ -121,7 +121,7 @@
     "cookieName": "token",
     "description": "Authentication",
     "logoutTime": 60,
-     {% if iap_release == 2023.2 %}
+    {% if iap_release >= 2023.2 %}
     "sso": {
       "enabled": false,
       "config": ""


### PR DESCRIPTION
If you install IAP for the second time with the deployer, this missing SSO parameter in authenticationProps cause a failure in IAP 2023.2.x that doesn't permit IAP initialize.